### PR TITLE
Add content that was removed from README.md in wptide/wptide

### DIFF
--- a/_docpress/_docpress.json
+++ b/_docpress/_docpress.json
@@ -231,6 +231,11 @@
                 "title": "Settings",
                 "depth": 2,
                 "id": "settings"
+              },
+              {
+                "title": "Usage",
+                "depth": 2,
+                "id": "usage"
               }
             ]
           },
@@ -249,6 +254,11 @@
                 "title": "Settings",
                 "depth": 2,
                 "id": "settings"
+              },
+              {
+                "title": "Usage",
+                "depth": 2,
+                "id": "usage"
               }
             ]
           },
@@ -272,6 +282,11 @@
                 "title": "Running audits",
                 "depth": 2,
                 "id": "running-audits"
+              },
+              {
+                "title": "Usage",
+                "depth": 2,
+                "id": "usage"
               }
             ]
           },
@@ -672,6 +687,11 @@
           "title": "Settings",
           "depth": 2,
           "id": "settings"
+        },
+        {
+          "title": "Usage",
+          "depth": 2,
+          "id": "usage"
         }
       ]
     },
@@ -690,6 +710,11 @@
           "title": "Settings",
           "depth": 2,
           "id": "settings"
+        },
+        {
+          "title": "Usage",
+          "depth": 2,
+          "id": "usage"
         }
       ]
     },
@@ -713,6 +738,11 @@
           "title": "Running audits",
           "depth": 2,
           "id": "running-audits"
+        },
+        {
+          "title": "Usage",
+          "depth": 2,
+          "id": "usage"
         }
       ]
     },

--- a/_docpress/services/api.html
+++ b/_docpress/services/api.html
@@ -65,6 +65,16 @@ serving a theme and a REST API.</p>
 to start from scratch delete that directory and run <code>make api.setup</code> again. Be
 sure to stop the API with <code>make api.down</code> or <code>make down</code> and then start it again
 with <code>make api.up</code>.</p>
+<p>Running <code>make down</code> will stop all Docker services.</p>
+<p>If you see an error like this on OS X when bringing up the API you need to add the
+directory to the <code>Preferences -&gt; File Sharing</code> section of the Docker for Mac app.</p>
+<pre><code>ERROR: for gotide_api-mysql_1  Cannot start service api-mysql: b&apos;Mounts denied: ...&apos;
+</code></pre>
+<p>For local development you can manually set the <code>API_KEY</code> and <code>API_SECRET</code> for the
+<code>audit-server</code> user, which will automatically update the user meta values when
+<code>make api.setup</code> is ran. If you do not set those environment variables, or are
+running Tide in production, then you can access the auto generated key and secret
+from the <code>audit-server</code> user profile.</p>
 <h2 id="commands">Commands</h2>
 <table>
 <thead>

--- a/_docpress/services/lighthouse.html
+++ b/_docpress/services/lighthouse.html
@@ -31,6 +31,7 @@
                 <li class="heading-item -depth-2"><a class="hlink link-commands" href="#commands">Commands</a></li>
                 <li class="heading-item -depth-2"><a class="hlink link-settings" href="#settings">Settings</a></li>
                 <li class="heading-item -depth-2"><a class="hlink link-running-audits" href="#running-audits">Running audits</a></li>
+                <li class="heading-item -depth-2"><a class="hlink link-usage" href="#usage">Usage</a></li>
               </ul>
             </li>
             <li class="menu-item -level-2"><a class="link title  link-servicesmongodb" href="services/mongodb.html">MongoDB</a>
@@ -117,6 +118,19 @@ Lighthouse reports against themes, then sends the results back to the Tide API.<
 </table>
 <h2 id="running-audits">Running audits</h2>
 <p>Details on running Lighthouse audits are <a href="https://github.com/xwp/go-tide/wiki/Running-Lighthouse-audits">available in the Tide wiki</a>.</p>
+<h2 id="usage">Usage</h2>
+<p>First build the Lighthouse Server Docker image:</p>
+<pre><code>$ make lighthouse.build.image
+</code></pre>
+<p>Next start the Lighthouse Server in isolation:</p>
+<pre><code>$ make lighthouse.up
+</code></pre>
+<p>You can combine the previous two steps and simply run:</p>
+<pre><code>$ make lighthouse.build.up
+</code></pre>
+<p>Take the isolated Lighthouse Server down:</p>
+<pre><code>$ make lighthouse.down
+</code></pre>
 
     </div>
     <div class="footer-nav">

--- a/_docpress/services/mongodb.html
+++ b/_docpress/services/mongodb.html
@@ -54,7 +54,7 @@
       <div class="right"><a class="iconlink" href="https://github.com/wptide/docs" data-title="wptide/docs"><span class="icon -github"></span></a><a class="iconlink" href="https://make.wordpress.org/tide/" data-title="make.wordpress.org/tide"><svg version="1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000"><path d="M10 500a490 490 0 1 0 980 0 490 490 0 0 0-980 0zm38 0c0-66 14-128 39-184l216 591A452 452 0 0 1 48 500zm452 452c-44 0-87-6-128-18l136-394 139 380 3 7c-47 16-97 25-150 25zm366-460a427 427 0 0 0 31-209 450 450 0 0 1-170 608l139-399zm-98-140c17 30 37 69 37 125 0 39-11 87-34 146l-45 151-164-486c28-1 52-4 52-4 24-3 22-39-3-38 0 0-73 6-120 6-45 0-119-6-119-6-25-1-28 36-3 38l47 4 71 193-99 297-165-490c27-1 52-4 52-4 24-3 21-39-3-38 0 0-73 6-121 6h-29a452 452 0 0 1 683-85l-5-1c-45 0-76 39-76 80 0 38 21 69 44 106z"/></svg></a></div>
     </div>
     <div class="markdown-body"><h1 id="mongodb">MongoDB</h1>
-<p>By default MongoDB is used as the local message provider for the Lighthouse/PHPCS Servers. In order for these services to use MongoDB you&apos;ll need to ensure the following settings are in you <code>.env</code>. The only setting that you should <strong>not</strong> change is <code>MONGO_HOST</code>.</p>
+<p>By default MongoDB is used as the local message provider for the Lighthouse/PHPCS Servers. In order for these services to use MongoDB you&apos;ll need to ensure the following settings are in your <code>.env</code>. The only setting that you should <strong>not</strong> change is <code>MONGO_HOST</code>.</p>
 <table>
 <thead>
 <tr>

--- a/_docpress/services/phpcs.html
+++ b/_docpress/services/phpcs.html
@@ -28,6 +28,7 @@
               <ul class="headings heading-list">
                 <li class="heading-item -depth-2"><a class="hlink link-commands" href="#commands">Commands</a></li>
                 <li class="heading-item -depth-2"><a class="hlink link-settings" href="#settings">Settings</a></li>
+                <li class="heading-item -depth-2"><a class="hlink link-usage" href="#usage">Usage</a></li>
               </ul>
             </li>
             <li class="menu-item -level-2"><a class="link title  link-serviceslighthouse" href="services/lighthouse.html">Lighthouse Server</a>
@@ -114,6 +115,19 @@ reports against both plugins and themes, then sends the results back to the Tide
 </tr>
 </tbody>
 </table>
+<h2 id="usage">Usage</h2>
+<p>First build the PHPCS Server Docker image:</p>
+<pre><code>$ make phpcs.build.image
+</code></pre>
+<p>Next start the PHPCS Server in isolation:</p>
+<pre><code>$ make phpcs.up
+</code></pre>
+<p>You can combine the previous two steps and simply run:</p>
+<pre><code>$ make phpcs.build.up
+</code></pre>
+<p>Take the isolated PHPCS Server down:</p>
+<pre><code>$ make phpcs.down
+</code></pre>
 
     </div>
     <div class="footer-nav">

--- a/_docpress/services/sync.html
+++ b/_docpress/services/sync.html
@@ -26,6 +26,7 @@
               <ul class="headings heading-list">
                 <li class="heading-item -depth-2"><a class="hlink link-commands" href="#commands">Commands</a></li>
                 <li class="heading-item -depth-2"><a class="hlink link-settings" href="#settings">Settings</a></li>
+                <li class="heading-item -depth-2"><a class="hlink link-usage" href="#usage">Usage</a></li>
               </ul>
             </li>
             <li class="menu-item -level-2"><a class="link title  link-servicesphpcs" href="services/phpcs.html">PHPCS Server</a>
@@ -154,6 +155,19 @@ plugins to process and writes them to a queue.</p>
 </tr>
 </tbody>
 </table>
+<h2 id="usage">Usage</h2>
+<p>First build the Sync Server Docker image:</p>
+<pre><code>$ make sync.build.image
+</code></pre>
+<p>Next start the Sync Server in isolation:</p>
+<pre><code>$ make sync.up
+</code></pre>
+<p>You can combine the previous two steps and simply run:</p>
+<pre><code>$ make sync.build.up
+</code></pre>
+<p>Take the isolated Sync Server down:</p>
+<pre><code>$ make sync.down
+</code></pre>
 
     </div>
     <div class="footer-nav">

--- a/docs/services/api.md
+++ b/docs/services/api.md
@@ -8,6 +8,21 @@ to start from scratch delete that directory and run `make api.setup` again. Be
 sure to stop the API with `make api.down` or `make down` and then start it again 
 with `make api.up`.
 
+Running `make down` will stop all Docker services.
+
+If you see an error like this on OS X when bringing up the API you need to add the 
+directory to the `Preferences -> File Sharing` section of the Docker for Mac app.
+
+```
+ERROR: for gotide_api-mysql_1  Cannot start service api-mysql: b'Mounts denied: ...'
+```
+
+For local development you can manually set the `API_KEY` and `API_SECRET` for the 
+`audit-server` user, which will automatically update the user meta values when 
+`make api.setup` is ran. If you do not set those environment variables, or are 
+running Tide in production, then you can access the auto generated key and secret 
+from the `audit-server` user profile. 
+
 ## Commands
 
 | Variable | Description |

--- a/docs/services/lighthouse.md
+++ b/docs/services/lighthouse.md
@@ -23,3 +23,29 @@ Lighthouse reports against themes, then sends the results back to the Tide API.
 ## Running audits
 
 Details on running Lighthouse audits are [available in the Tide wiki](https://github.com/xwp/go-tide/wiki/Running-Lighthouse-audits).
+
+## Usage
+
+First build the Lighthouse Server Docker image:
+
+```
+$ make lighthouse.build.image
+```
+
+Next start the Lighthouse Server in isolation:
+
+```
+$ make lighthouse.up
+```
+
+You can combine the previous two steps and simply run:
+
+```
+$ make lighthouse.build.up
+```
+
+Take the isolated Lighthouse Server down:
+
+```
+$ make lighthouse.down
+```

--- a/docs/services/mongodb.md
+++ b/docs/services/mongodb.md
@@ -1,6 +1,6 @@
 # MongoDB
 
-By default MongoDB is used as the local message provider for the Lighthouse/PHPCS Servers. In order for these services to use MongoDB you'll need to ensure the following settings are in you `.env`. The only setting that you should **not** change is `MONGO_HOST`.
+By default MongoDB is used as the local message provider for the Lighthouse/PHPCS Servers. In order for these services to use MongoDB you'll need to ensure the following settings are in your `.env`. The only setting that you should **not** change is `MONGO_HOST`.
 
 | Variable | Description |
 | :--- | :--- |

--- a/docs/services/phpcs.md
+++ b/docs/services/phpcs.md
@@ -20,3 +20,29 @@ reports against both plugins and themes, then sends the results back to the Tide
 | `PHPCS_MESSAGE_PROVIDER` | Queue audit messages using the local MongoDB, Google Cloud Firestore, or AWS SQS. Must be one of: `local`, `firestore`, `sqs`. Default is `local`. |
 | `PHPCS_STORAGE_PROVIDER` | Upload reports to the local file system, Google Cloud Storage, or AWS S3. Must be one of: `local`, `gcs`, `s3`. Default is `local`. |
 | `PHPCS_TEMP_FOLDER` | Sets the temporary folder inside the container used to store downloaded files. Default is `/tmp`. |
+
+## Usage
+
+First build the PHPCS Server Docker image:
+
+```
+$ make phpcs.build.image
+```
+
+Next start the PHPCS Server in isolation:
+
+```
+$ make phpcs.up
+```
+
+You can combine the previous two steps and simply run:
+
+```
+$ make phpcs.build.up
+```
+
+Take the isolated PHPCS Server down:
+
+```
+$ make phpcs.down
+```

--- a/docs/services/sync.md
+++ b/docs/services/sync.md
@@ -30,3 +30,29 @@ plugins to process and writes them to a queue.
 | `SYNC_PHPCS_ACTIVE` | Send messages to the PHPCS SQS queue. Must be one of: `on`, `off`. Default is `on`. |
 | `SYNC_POOL_DELAY` | The wait time in seconds between the wp.org theme and plugin ingests. Default is `600`. |
 | `SYNC_POOL_WORKERS` | The number of workers (concurrent goroutines) the server will create to ingest the wp.org API. Default is `125`. |
+
+## Usage
+
+First build the Sync Server Docker image:
+
+```
+$ make sync.build.image
+```
+
+Next start the Sync Server in isolation:
+
+```
+$ make sync.up
+```
+
+You can combine the previous two steps and simply run:
+
+```
+$ make sync.build.up
+```
+
+Take the isolated Sync Server down:
+
+```
+$ make sync.down
+```


### PR DESCRIPTION
Since we are simplifying README.md over on the main repo, this information needs to go in the full documentation instead.