### PR TITLE
Add missing forward slash in URL

### DIFF
--- a/_docpress/services/api.html
+++ b/_docpress/services/api.html
@@ -561,7 +561,7 @@
 </table>
 <h4 id="usage">Usage</h4>
 <p>Retrieve the audit with a <code>GET</code> request:</p>
-<pre><code>curl -X GET http://tide.local/api/tide/v1/audit&lt;id&gt;
+<pre><code>curl -X GET http://tide.local/api/tide/v1/audit/&lt;id&gt;
 </code></pre>
 <p>Update the title by making a <code>POST</code> request:</p>
 <pre><code>curl -X POST \

--- a/docs/services/api.md
+++ b/docs/services/api.md
@@ -192,7 +192,7 @@ Delete an audit by `id`.
 Retrieve the audit with a `GET` request:
 
 ```
-curl -X GET http://tide.local/api/tide/v1/audit<id>
+curl -X GET http://tide.local/api/tide/v1/audit/<id>
 ```
 
 Update the title by making a `POST` request:


### PR DESCRIPTION
Adds a missing forward slash to a URL for the API docs.