### PR TITLE
Docs: Fix multiple typos, grammar, and formatting issues

### DIFF
--- a/docs/aws/index.md
+++ b/docs/aws/index.md
@@ -8,9 +8,9 @@ We no longer support deploying to AWS. However, you can still use Amazon S3 for 
 | `AWS_API_KEY` | The AWS API key. |
 | `AWS_API_SECRET` | The AWS API secret. |
 | `AWS_S3_BUCKET_NAME` | The name of the S3 bucket.  |
-| `AWS_S3_REGION` | The region of the S3 bucket. Default is `us-west-2`. See a list of available [AWS Regions and Enpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).  |
+| `AWS_S3_REGION` | The region of the S3 bucket. Default is `us-west-2`. See a list of available [AWS Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).  |
 | `AWS_S3_VERSION` | The S3 API version. Default is `2006-03-01`. |
 | `AWS_SQS_QUEUE_LH` | The name of the SQS queue for the Lighthouse Server. |
 | `AWS_SQS_QUEUE_PHPCS` | The name of the SQS queue for the PHPCS Server. |
-| `AWS_SQS_REGION` | The region of the SQS queue. Default is `us-west-2`. See a list of available [AWS Regions and Enpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#sqs_region).  |
+| `AWS_SQS_REGION` | The region of the SQS queue. Default is `us-west-2`. See a list of available [AWS Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#sqs_region).  |
 | `AWS_SQS_VERSION` | The SQS API version. Default is `2012-11-05`. |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,7 +24,7 @@ This project and everyone participating in it is governed by the [Tide Code of C
     - If you are not familiar with branching please read [_A successful Git branching model_](http://nvie.com/posts/a-successful-git-branching-model/) before you go any further.
 - If adding a new feature:
     - Add accompanying test case.
-    - Provide convincing reason to add this feature. Ideally you should open a suggestion issue first and have it green-lit before working on it.
+    - Provide a convincing reason to add this feature. Ideally, you should open a suggestion issue first and have it green-lit before working on it.
 - If fixing a bug:
     - Provide detailed description of the bug in the PR. Live demo preferred.
     - Add appropriate test coverage if applicable.

--- a/docs/gcp/google-cloud-firestore.md
+++ b/docs/gcp/google-cloud-firestore.md
@@ -7,7 +7,7 @@ If you want to use Cloud Firestore as the database provider for the Sync Server 
 | Variable | Description |
 | :--- | :--- |
 | `GCF_QUEUE_LH` | Specifies which collection in Cloud Firestore to use for the Lighthouse message queue. This is a Firestore collection **path**. Default is `queue-lighthouse`. |
-| `GCF_QUEUE_PHPCS` | Specifies which collection in CLoud Firestore to use for the PHPCS message queue. This is a Firestore collection **path**. Default is `queue-phpcs`. |
+| `GCF_QUEUE_PHPCS` | Specifies which collection in Cloud Firestore to use for the PHPCS message queue. This is a Firestore collection **path**. Default is `queue-phpcs`. |
 
 ## Setup
 

--- a/docs/gcp/google-cloud-sql.md
+++ b/docs/gcp/google-cloud-sql.md
@@ -6,7 +6,7 @@ Deploying a database to Cloud SQL for the WordPress API only requires a bit of c
 
 | Variable | Description |
 | :--- | :--- |
-| `GCSQL_API_BACKUP_START_TIME` | he start time of daily backups, specified in the 24 hour format - HH:MM, in the UTC timezone. This is the window of time when you would like backups to start. [Learn more](https://cloud.google.com/sql/docs/mysql/instance-settings#backups-and-binary-logging-2ndgen). |
+| `GCSQL_API_BACKUP_START_TIME` | The start time of daily backups, specified in the 24 hour format - HH:MM, in the UTC timezone. This is the window of time when you would like backups to start. [Learn more](https://cloud.google.com/sql/docs/mysql/instance-settings#backups-and-binary-logging-2ndgen). |
 | `GCSQL_API_DATABASE_VERSION` | The database engine type and version. Must be one of: `MYSQL_5_6`, `MYSQL_5_7`. |
 | `GCSQL_API_DB_NAME` | Name of the database. |
 | `GCSQL_API_DB_PASSWORD` | Password used to access the database. |

--- a/docs/gcp/google-kubernetes-engine.md
+++ b/docs/gcp/google-kubernetes-engine.md
@@ -8,12 +8,12 @@ All the goroutines are deployed to a Kubernetes cluster with the same basic step
 
 | Variable | Description |
 | :--- | :--- |
-| `GKE_LH_CLUSTER` | The name of the cluster. Default is`lighthouse-server`. |
+| `GKE_LH_CLUSTER` | The name of the cluster. Default is `lighthouse-server`. |
 | `GKE_LH_CLUSTER_VERSION` | The Kubernetes version to use for the master and nodes. You can check which Kubernetes versions are default and available in a given zone by running the following command: |
 | | `gcloud container get-server-config --zone [COMPUTE-ZONE]` |
 | `GKE_LH_CPU_PERCENT` | The average percent CPU utilization across all pods. Must be a range of `1-100`. |
 | `GKE_LH_DISK_SIZE` | Size in GB for node VM boot disks. An example value is `100`. |
-| `GKE_LH_IMAGE` | The name of the Docker image. Default is`lighthouse-server`. |
+| `GKE_LH_IMAGE` | The name of the Docker image. Default is `lighthouse-server`. |
 | `GKE_LH_MACHINE_TYPE` | The type of machine to use for nodes. An example value is `n1-standard-1`. |
 | `GKE_LH_MAX_NODES` | Maximum number of nodes to which the node pool can scale. |
 | `GKE_LH_MAX_PODS` |  Maximum number of Pods you want to run based on the CPU utilization of your existing Pods. |

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -4,6 +4,6 @@ Setting up Tide locally is fairly straight forward and consists of the following
 
 1. Installing all the [prerequisite](prerequisites.md) software.
 1. [Cloning](cloning.md) the Tide repository into your `$GOPATH`.
-1. Finally. completing a handful of [setup](setup.md) steps in the form of `make` commands.
+1. Finally, completing a handful of [setup](setup.md) steps in the form of `make` commands.
 
 _If you run into issues while getting Tide installed, please contact us so we can address it and update the documentation for others._

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -10,7 +10,7 @@ serving a theme and a REST API.
 
 ## Commands
 
-There are several `make` commands you can use to manage the Tide services. Some you run manually, and some are ran by other `make` commands — these are the root level ones. There are additional commands associated with each service, which we'll see later in this section. If you run `make` from the root directory a full list of commands will output to your shell.
+There are several `make` commands you can use to manage the Tide services. Some you run manually, and some are run by other `make` commands — these are the root level ones. There are additional commands associated with each service, which we'll see later in this section. If you run `make` from the root directory a full list of commands will output to your shell.
 
 | Command | Description |
 | :--- | :--- |

--- a/docs/services/lighthouse-server.md
+++ b/docs/services/lighthouse-server.md
@@ -76,7 +76,7 @@ The following demonstrates how a WordPress theme is run through a Lighthouse aud
 
 ![](../images/lighthouse-server-checksum.png)
 
-1. The source code is ran through `gocloc` to get code information.
+1. The source code is run through `gocloc` to get code information.
 
 ![](../images/lighthouse-server-code-info.png)
 


### PR DESCRIPTION
## Summary
Fixed multiple typos, grammar issues, and formatting inconsistencies across the documentation.

## Files Changed (8 files, 10 fixes)

### Grammar Fixes
- [docs/contributing.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/contributing.md:0:0-0:0): Added missing article "a" before "convincing reason"
- [docs/services/lighthouse-server.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/services/lighthouse-server.md:0:0-0:0): "is ran through" → "is run through"
- [docs/services/index.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/services/index.md:0:0-0:0): "are ran by" → "are run by"

### Typo Fixes
- [docs/gcp/google-cloud-sql.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/gcp/google-cloud-sql.md:0:0-0:0): "he start time" → "The start time"
- [docs/gcp/google-cloud-firestore.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/gcp/google-cloud-firestore.md:0:0-0:0): "CLoud" → "Cloud"
- [docs/aws/index.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/aws/index.md:0:0-0:0): "Enpoints" → "Endpoints" (2 instances)

### Formatting Fixes
- [docs/gcp/google-kubernetes-engine.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/gcp/google-kubernetes-engine.md:0:0-0:0): Added missing space before backticks (2 instances)
- [docs/installation/index.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/docs/docs/installation/index.md:0:0-0:0): "Finally." → "Finally," (period to comma)