### PR TITLE
Fix typo, grammar, and upgrade HTTP links to HTTPS

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -42,5 +42,5 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,7 +21,7 @@ This project and everyone participating in it is governed by the [Tide Code of C
 ## Pull Request Guidelines
 
 - Checkout a topic branch from `develop` and merge back against `develop`.
-    - If you are not familiar with branching please read [_A successful Git branching model_](http://nvie.com/posts/a-successful-git-branching-model/) before you go any further.
+    - If you are not familiar with branching please read [_A successful Git branching model_](https://nvie.com/posts/a-successful-git-branching-model/) before you go any further.
 - If adding a new feature:
     - Add accompanying test case.
     - Provide a convincing reason to add this feature. Ideally, you should open a suggestion issue first and have it green-lit before working on it.

--- a/docs/gcp/index.md
+++ b/docs/gcp/index.md
@@ -14,7 +14,7 @@ If you are going to use any GCP resources for local development or plan to deplo
 
 ## Service Account
 
-Go to the [Credentials](https://console.cloud.google.com/apis/credentials/) section of your project in the Console. Click **Create credentials** and then click **Service account key**. For the Service account, select **App Engine app default service account**. Then click **Create** to generate and download the JSON service account key file to your local machine. Save the file as `service-account.json` in the projects root directory. We will use this file to connect to Google Cloud Platform services and API's like Cloud Storage and Cloud SQL.
+Go to the [Credentials](https://console.cloud.google.com/apis/credentials/) section of your project in the Console. Click **Create credentials** and then click **Service account key**. For the Service account, select **App Engine app default service account**. Then click **Create** to generate and download the JSON service account key file to your local machine. Save the file as `service-account.json` in the projects root directory. We will use this file to connect to Google Cloud Platform services and APIs like Cloud Storage and Cloud SQL.
 
 _If **App Engine app default service account** is missing from the list of service accounts, then you haven't activated App Engine for your project or it is still initializing._
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ You can also run your own Tide instance and do your own customized reports if yo
 
 ### Architecture diagram
 
-The following diagram notes which Google Cloud Platform (GCP) components are used to represent the four Tide services, and how the themes and plugins API on WP.org connects to the Sync Server. The basic flow is that a User or an API Client will make a request to the Tide REST API, which sends back a response. The request could create messages in the queue where one or more services process them by running automated scripts and witting the results back to the API. Additionally, the Sync Server will poll the WP.org API's for new themes and plugins to add to the message queue.
+The following diagram notes which Google Cloud Platform (GCP) components are used to represent the four Tide services, and how the themes and plugins API on WP.org connects to the Sync Server. The basic flow is that a User or an API Client will make a request to the Tide REST API, which sends back a response. The request could create messages in the queue where one or more services process them by running automated scripts and writing the results back to the API. Additionally, the Sync Server will poll the WP.org API's for new themes and plugins to add to the message queue.
 
 ![](images/architecture-diagram.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Progress can be followed in the WordPress meta issue tracker at https://meta.tra
 
 Tide services are responsible for the following:
 
-* The [Sync Server](services/sync-server.md) polls the WordPress.org API's for themes and plugins to process and writes them to a queue.
+* The [Sync Server](services/sync-server.md) polls the WordPress.org APIs for themes and plugins to process and writes them to a queue.
 * The [PHPCS Server](services/phpcs-server.md) reads messages from a queue and runs reports against both plugins and themes, then sends the results back to the Tide API.
 * The [Lighthouse Server](services/lighthouse-server.md) reads messages from a queue and runs Google Lighthouse reports against the themes only, then sends the results back to the Tide API.
 * The [wptide.org](https://wptide.org) website includes both the documentation you are reading and also serves the JSON API endpoints from where the reports can be queried. Visit https://wptide.org/search to see examples of JSON reports.
@@ -49,7 +49,7 @@ You can also run your own Tide instance and do your own customized reports if yo
 
 ### Architecture diagram
 
-The following diagram notes which Google Cloud Platform (GCP) components are used to represent the four Tide services, and how the themes and plugins API on WP.org connects to the Sync Server. The basic flow is that a User or an API Client will make a request to the Tide REST API, which sends back a response. The request could create messages in the queue where one or more services process them by running automated scripts and writing the results back to the API. Additionally, the Sync Server will poll the WP.org API's for new themes and plugins to add to the message queue.
+The following diagram notes which Google Cloud Platform (GCP) components are used to represent the four Tide services, and how the themes and plugins API on WP.org connects to the Sync Server. The basic flow is that a User or an API Client will make a request to the Tide REST API, which sends back a response. The request could create messages in the queue where one or more services process them by running automated scripts and writing the results back to the API. Additionally, the Sync Server will poll the WP.org APIs for new themes and plugins to add to the message queue.
 
 ![](images/architecture-diagram.png)
 

--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -14,11 +14,11 @@ Install [Glide](https://glide.readthedocs.io/en/latest/#installing-glide), a pac
 
   - Use the shell script to try an automatically install it. `curl https://glide.sh/get | sh`
   - Download a [versioned release](https://github.com/Masterminds/glide/releases). Glide releases are semantically versioned.
-  - Use a system package manager to install Glide. For example, `brew install glide` can be used if you're using [Homebrew](http://brew.sh/) on Mac.
+  - Use a system package manager to install Glide. For example, `brew install glide` can be used if you're using [Homebrew](https://brew.sh/) on Mac.
   - The latest development snapshot can be installed with go get. For example, `go get -u github.com/Masterminds/glide`. This is not a release version.
 
 ## Make
 
-Install [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm) _(Windows only)_
+Install [Make for Windows](https://gnuwin32.sourceforge.net/packages/make.htm) _(Windows only)_
   - The `make` command is not available on Windows by default and you must install it to be able to use the Tide `make` commands.
   - Add `C:\zlib\bin` to your `$PATH` once you've installed the package.

--- a/docs/services/sync-server.md
+++ b/docs/services/sync-server.md
@@ -1,6 +1,6 @@
 # Sync server
 
-The Sync Server is a Go binary installed on an Alpine Linux Docker image that polls the wp.org API's for themes and plugins to process and writes them to a queue.
+The Sync Server is a Go binary installed on an Alpine Linux Docker image that polls the wp.org APIs for themes and plugins to process and writes them to a queue.
 
 Unless you have good reason to set the `SYNC_ACTIVE` environment variable to `on` you should leave the server set to `off` and not bring up the container by running `make sync.up`. Turning on the Sync Server will put around 50k audits in the queue and will take days to process locally and potentially lock up all your computers resources. A better way to audit wp.org themes and plugins would be to follow the instructions found in the [Run Audits](../installation/setup.md#run-audits) section of the setup page.
 


### PR DESCRIPTION
## Summary
This PR fixes documentation issues including a typo, grammar corrections, and security improvements.

## Changes

### 1. Typo Fix
- `witting` → `writing` in architecture description (docs/index.md)

### 2. Grammar Fix
- `API's` → `APIs` (plural, not possessive)
  - docs/index.md (2 occurrences)
  - docs/services/sync-server.md (1 occurrence)
  - docs/gcp/index.md (1 occurrence)

### 3. Security: HTTP → HTTPS
Upgraded all external HTTP links to secure HTTPS:
- brew.sh
- gnuwin32.sourceforge.net
- nvie.com
- contributor-covenant.org (2 links)

All HTTPS links verified to work correctly.